### PR TITLE
#1 add dist/*.js into package.json in eslint-plugin-closure

### DIFF
--- a/packages/eslint-plugin-closure/package.json
+++ b/packages/eslint-plugin-closure/package.json
@@ -18,6 +18,7 @@
   ],
   "files": [
     "lib/*.js",
+    "dist/*.js",
     "index.js",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
This is aim to fix the issue mentioned in #1 Cannot find module './dist/closure-eslint-plugin'. After npm install, required files under dist/ are missing.